### PR TITLE
fix(cli): Remove "Some content" placeholder from the `note new` subcommand

### DIFF
--- a/packages/kasten-cli/src/commands/note_new.ts
+++ b/packages/kasten-cli/src/commands/note_new.ts
@@ -9,6 +9,6 @@ export const command = new Command("new")
   .requiredOption("-t, --title <title>", "Note title")
   .action((args: { directory: string; title: string }) => {
     const zk = new Zettelkasten(args.directory);
-    const fileName = zk.newNote({ title: args.title, content: "some content" });
+    const fileName = zk.newNote({ title: args.title, content: "" });
     console.log(zk.getFullPath(fileName));
   });


### PR DESCRIPTION
Closes #5
